### PR TITLE
Add Deno

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ See also [the original blog post] for more discussion.
 | Awk        | No          | `GNU Awk 5.1.0, API: 3.0 (GNU MPFR 4.1.0, GNU MP 6.2.1)`
 | Bash       | No          | `GNU bash, version 5.1.4(1)-release (x86_64-pc-linux-gnu)`
 | C#         | No          | `Mono JIT compiler version 6.8.0.105`
+| Deno       | No          | `deno 1.11.0 (release, x86_64-unknown-linux-gnu)`
 | Lisp       | No          | `SBCL 2.1.1`
 | OCaml      | No          | `4.08.1`
 | Perl       | No          | `perl 5, version 32, subversion 1 (v5.32.1) built for x86_64-linux-gnu-thread-multi (with 46 registered patches...)`
@@ -51,7 +52,7 @@ In some cases, only a specific implementation has been tested, and it's not yet
 been determined what the actual documented or specified behavior is. In those
 cases, I've listed the versions tested, or links to reports.
 
-Node.js is listed here as a "Language" because JavaScript itself doesn't have
+Node.js (and Deno) is listed here as a "Language" because JavaScript itself doesn't have
 a builtin concept of standard output, so it takes an embedding like Node.js to
 connect JS features to command-line concepts such as standard output.
 


### PR DESCRIPTION
It looks like Deno does not have this bug because of its usage of Rust!
```sh
$ deno run hello_world.js > /dev/full
thread 'main' panicked at 'failed printing to stdout: No space left on device (os error 28)', library/std/src/io/stdio.rs:940:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
fatal runtime error: failed to initiate panic, error 5
Aborted (core dumped)
```