### PR TITLE
Add Meta's HackLang to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ See also [the original blog post] for more discussion.
 | Awk        | No          | `GNU Awk 5.1.0, API: 3.0 (GNU MPFR 4.1.0, GNU MP 6.2.1)`
 | Bash       | No          | `GNU bash, version 5.1.4(1)-release (x86_64-pc-linux-gnu)`
 | C#         | No          | `Mono JIT compiler version 6.8.0.105`
+| Hack       | No          | `HHVM 4.108` or above when using [HSL IO]
 | Deno       | No          | `deno 1.11.0 (release, x86_64-unknown-linux-gnu)`
 | Lisp       | No          | `SBCL 2.1.1`
 | OCaml      | No          | `4.08.1`
@@ -66,3 +67,4 @@ or corrections are welcome!
 [Wikipedia's list of "Hello, World!" programs]: https://en.wikipedia.org/wiki/%22Hello,_World!%22_program#Examples
 [The Hello World Collection]: http://helloworldcollection.de/
 [the original blog post]: https://blog.sunfishcode.online/bugs-in-hello-world/
+[HSL IO]: https://docs.hhvm.com/hack/getting-started/input-and-output


### PR DESCRIPTION
https://gist.github.com/fredemmott/465fb05734afb20e6f6fd59a7d8a807e

Hack code using functions inherited from PHP have the bug (to retain backwards compatibility), but the Hack Standard Library raises errors.

The HSL (including HSL IO) was made a built-in part of HHVM (the runtime for Hack, formerly also a PHP runtime) 4.108: https://hhvm.com/blog/2021/05/04/hhvm-4.108.html