### PR TITLE
Add Lua language

### DIFF
--- a/Examples.md
+++ b/Examples.md
@@ -20,3 +20,10 @@ int main(void) {
     return EXIT_SUCCESS;
 }
 ```
+
+## Lua
+
+```lua
+io.write("Hello World\n")
+assert(io:flush())
+```

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ See also [the original blog post] for more discussion.
 | Haskell    | `The Glorious Glasgow Haskell Compilation System, version 8.8.4` |
 | Java       | This is [documented behavior in Java], [since Java 1.0] |
 | Julia      | https://news.ycombinator.com/item?id=30619661 |
+| Lua        | `v5.3.3`                                   | [Example](Examples.md#Lua)
 | Nim        | `Nim Compiler Version 1.6.4`               |
 | Node.js    | `v12.21.0`                                 |
 | Pascal     | https://news.ycombinator.com/item?id=30613381 |


### PR DESCRIPTION
Adds the Lua language.

A [traditional hello world](https://www.lua.org/pil/1.html) has the bug:

```console
$ lua5.3 -e 'print("Hello World")'; echo $?
Hello World
0
$ lua5.3 -e 'print("Hello World")' > /dev/full; echo $?
0
```

How to fix it:

```console
$ lua5.3 -e 'io.write("Hello World\n");assert(io:flush())'; echo $?
Hello World
0
$ lua5.3 -e 'io.write("Hello World\n");assert(io:flush())' > /dev/full ; echo $?
lua5.3: (command line):1: No space left on device
stack traceback:
        [C]: in function 'assert'
        (command line):1: in main chunk
        [C]: in ?
1
```
