### PR TITLE
Add Hare as language without the bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ See also [the original blog post] for more discussion.
 | Deno       | `deno 1.11.0 (release, x86_64-unknown-linux-gnu)`
 | Erlang/OTP | `Erlang/OTP 26.0` or above
 | Hack       | `HHVM 4.108` or above when using [HSL IO]
+| Hare       | `hare` + `harec` 20230222 snapshot
 | Lisp       | `SBCL 2.1.1`
 | OCaml      | `4.08.1`
 | Perl       | `perl 5, version 32, subversion 1 (v5.32.1) built for x86_64-linux-gnu-thread-multi (with 46 registered patches...)`


### PR DESCRIPTION
I/O Errors in Hare must be handled, either via assertion or match statement.
Hello World example on <https://harelang.org/> uses the `!` assertion symbol
and aborts on I/O error, like so:
```
$ hare run hello.ha >/dev/full
Abort: Assertion failed: error occured at /home/haelwenn/tmp/2023-05/hello.ha:12:4
Aborted
$ echo $?
134
```
